### PR TITLE
fix currency selector going behind "preorder" banner

### DIFF
--- a/src/pages/Content/content.styles.scss
+++ b/src/pages/Content/content.styles.scss
@@ -98,6 +98,8 @@
       border: 1px solid #E8E8E8;
       width: 100%;
       margin-top: 40px;
+      position: relative;
+      z-index: 14;
     }
 
     &_row {


### PR DESCRIPTION
thanks for this lovely extension, here's a small fix for the currency selector having a weird interaction with the banner elements (for preorders)

<img width="93" alt="image" src="https://user-images.githubusercontent.com/177701/230661294-73e8e445-0713-409f-ae5b-d68432e91972.png">
