### PR TITLE
Add BPM Tapping Functionality to Track Component

### DIFF
--- a/src/pages/Content/TralbumPage/CurrentTrackTapBpm.tsx
+++ b/src/pages/Content/TralbumPage/CurrentTrackTapBpm.tsx
@@ -1,0 +1,35 @@
+import React, { useEffect } from 'react';
+import useTapper from './useTapper';
+export default function CurrentTrackTapBpm() {
+  const { bpm, tap, reset } = useTapper();
+
+  useEffect(() => {
+    const handleKeyPress = (event) => {
+      if (event.key === 'b' || event.key === 'B') {
+        tap();
+      } else if (event.key === 'r' || event.key === 'R') {
+        reset();
+      }
+    };
+
+    window.addEventListener('keypress', handleKeyPress);
+    return () => {
+      window.removeEventListener('keypress', handleKeyPress);
+    };
+  }, [tap, reset]);
+
+  return (
+    <div>
+      <button
+        className="BandcampTempoAdjust__button"
+        onClick={tap}
+        onContextMenu={(e) => {
+          e.preventDefault();
+          reset();
+        }}
+      >
+        {bpm ? `${bpm} BPM` : 'tap'}
+      </button>
+    </div>
+  );
+}

--- a/src/pages/Content/TralbumPage/index.tsx
+++ b/src/pages/Content/TralbumPage/index.tsx
@@ -6,6 +6,7 @@ import AlbumTrackBpms from './AlbumTrackBpms';
 import { AudioProvider } from '../AudioContext';
 import CurrentTrackBpm from './CurrentTrackBpm';
 import PitchAdjust from '../PitchAdjust';
+import CurrentTrackTapBpm from './CurrentTrackTapBpm';
 
 const getCurrTrackUrl = () =>
   document.querySelector('.title_link')?.getAttribute('href')?.trim();
@@ -39,7 +40,9 @@ const TralbumPage = () => {
             justifyContent: 'flex-end',
           }}
         >
-          <CurrentTrackBpm />
+          <CurrentTrackBpm  />
+          <span>or </span>
+          <CurrentTrackTapBpm />
         </div>
       </div>
     </AudioProvider>

--- a/src/pages/Content/TralbumPage/useTapper.tsx
+++ b/src/pages/Content/TralbumPage/useTapper.tsx
@@ -1,0 +1,24 @@
+import { useState } from 'react';
+
+const useTapper = () => {
+  const [bpm, setBpm] = useState(0);
+  const cue = useState<number[]>([])[0];
+
+  const tap = () => {
+    const now = Date.now();
+    cue.push(now);
+    cue.length > 1 && setBpm(calculateBpm());
+    cue.length > 1 && now - cue[0] > 2000 && reset();
+  };
+
+  const reset = () => (cue.length = 0);
+
+  const calculateBpm = () => {
+    const duration = cue[cue.length - 1] - cue[0];
+    return Math.round(((60000 * (cue.length - 1)) / duration) * 10) / 10;
+  };
+
+  return { bpm, tap, reset };
+};
+
+export default useTapper;


### PR DESCRIPTION
A new feature for calculating BPM of a current track using tap. The implementation includes a custom hook useTapper and an updated CurrentTrackTapBpm component. 

This feature compensates for the automatic BPM detector's inaccuracies and its inability to work with speed-adjusted tracks, offering a reliable manual alternative.

Users can tap the button or press 'b'/'B' to calculate the BPM of the current track.
Pressing 'r'/'R' or right-clicking the button resets the BPM.
