### PR TITLE
fix for storage collect

### DIFF
--- a/apps/bandcamp-tempo-adjust/src/entrypoints/bandcamp.content/BpmContext.tsx
+++ b/apps/bandcamp-tempo-adjust/src/entrypoints/bandcamp.content/BpmContext.tsx
@@ -1,5 +1,6 @@
 import produce from 'immer';
 import React, { createContext, useReducer } from 'react';
+import browser from 'webextension-polyfill';
 import { analyzeAudio } from '../../utils/analyzeAudio';
 import { TrackInfoByUrl as TrackInfoStore } from '~/types';
 import { hasAllPermissions } from '../../utils/hasAllPermissions';

--- a/apps/bandcamp-tempo-adjust/src/utils/fetchBandcampTrackInfoStore.ts
+++ b/apps/bandcamp-tempo-adjust/src/utils/fetchBandcampTrackInfoStore.ts
@@ -35,12 +35,13 @@ export async function fetchBandcampTrackInfoStore() {
   const playableTracks = tralbum.trackinfo.filter(
     (track): track is PlayableTrackInfo => !!(track.title_link && track.file)
   );
-  const getFromStorage =
-    browser.storage?.local.get || (() => Promise.resolve({}));
+  const getFromStorage = browser.storage?.local?.get
+    ? (keys: string[]) => browser.storage.local.get(keys)
+    : (() => Promise.resolve({} as Record<string, { bpm?: number }>));
 
-  const storageGet = await getFromStorage(
+  const storageGet = (await getFromStorage(
     playableTracks.map(({ title_link }) => title_link)
-  );
+  )) as Record<string, { bpm?: number }>;
   return playableTracks.reduce((acc, track) => {
     const fullUrl = Object.values(track.file).find((possibleUrl) =>
       /https:\/\/\w+.bcbits.com/g.test(possibleUrl)


### PR DESCRIPTION
vibecoded the following fix:

**Fix Storage API Illegal Invocation Error**
Fixes the console error "Illegal invocation: Function must be called on an object of type StorageArea" by preserving the this context when calling browser.storage.local.get().
The storage method was being extracted into a variable, losing its context. Now it's wrapped in an arrow function to maintain proper binding.